### PR TITLE
add matchdep to load all grunt tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -134,18 +134,8 @@ module.exports = function(grunt) {
   });
 
 
-  // These plugins provide necessary tasks.
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-contrib-concat');
-  grunt.loadNpmTasks('grunt-contrib-connect');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-contrib-qunit');
-  grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-recess');
-  grunt.loadNpmTasks('browserstack-runner');
-
+  // load all grunt tasks
+  require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
 
   // Test task.
   var testSubtasks = ['jshint', 'qunit'];

--- a/package.json
+++ b/package.json
@@ -32,5 +32,6 @@
     , "grunt-recess": "~0.3.3"
     , "browserstack-runner": "~0.0.11"
     , "bower": "~1"
+    , "matchdep": "~0.1.2"
   }
 }


### PR DESCRIPTION
Using matchdep to load all grunt tasks.

Save more time than add grunt task one by one.
